### PR TITLE
feat : DB Replication을 통한 데이터베이스 부하 분산

### DIFF
--- a/src/main/java/com/example/soonsul/DBReplication/common/DataSourceType.java
+++ b/src/main/java/com/example/soonsul/DBReplication/common/DataSourceType.java
@@ -1,0 +1,5 @@
+package com.example.soonsul.DBReplication.common;
+
+public enum DataSourceType {
+    Master, Slave
+}

--- a/src/main/java/com/example/soonsul/DBReplication/datasource/MasterDataSourceConfig.java
+++ b/src/main/java/com/example/soonsul/DBReplication/datasource/MasterDataSourceConfig.java
@@ -1,0 +1,25 @@
+package com.example.soonsul.DBReplication.datasource;
+
+import com.zaxxer.hikari.HikariDataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import javax.sql.DataSource;
+
+@Configuration
+@Slf4j
+public class MasterDataSourceConfig {
+
+    @Primary
+    @Bean(name = "masterDataSource")
+    @ConfigurationProperties(prefix="spring.datasource.master.hikari")
+    public DataSource masterDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/soonsul/DBReplication/datasource/SlaveDataSourceConfig.java
+++ b/src/main/java/com/example/soonsul/DBReplication/datasource/SlaveDataSourceConfig.java
@@ -1,0 +1,24 @@
+package com.example.soonsul.DBReplication.datasource;
+
+import com.zaxxer.hikari.HikariDataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+@Configuration
+@Slf4j
+public class SlaveDataSourceConfig {
+
+    @Bean(name = "slaveDataSource")
+    @ConfigurationProperties(prefix="spring.datasource.slave.hikari")
+    public DataSource slaveDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/soonsul/DBReplication/replication/ReplicationRoutingDataSource.java
+++ b/src/main/java/com/example/soonsul/DBReplication/replication/ReplicationRoutingDataSource.java
@@ -1,0 +1,17 @@
+package com.example.soonsul.DBReplication.replication;
+
+import com.example.soonsul.DBReplication.common.DataSourceType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Slf4j
+public class ReplicationRoutingDataSource extends AbstractRoutingDataSource{
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        DataSourceType dataSourceType = TransactionSynchronizationManager.isCurrentTransactionReadOnly() ? DataSourceType.Slave : DataSourceType.Master;
+        return dataSourceType;
+    }
+
+}

--- a/src/main/java/com/example/soonsul/DBReplication/replication/RoutingDataSourceConfig.java
+++ b/src/main/java/com/example/soonsul/DBReplication/replication/RoutingDataSourceConfig.java
@@ -1,0 +1,41 @@
+package com.example.soonsul.DBReplication.replication;
+
+import com.example.soonsul.DBReplication.common.DataSourceType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@Slf4j
+public class RoutingDataSourceConfig {
+
+    @Bean(name = "routingDataSource")
+    public DataSource routingDataSource(
+            @Qualifier("masterDataSource") final DataSource masterDataSource,
+            @Qualifier("slaveDataSource") final DataSource slaveDataSource
+    ) {
+
+        ReplicationRoutingDataSource routingDataSource = new ReplicationRoutingDataSource();
+
+        Map<Object, Object> dataSourceMap = new HashMap<>();
+
+        dataSourceMap.put(DataSourceType.Master, masterDataSource);
+        dataSourceMap.put(DataSourceType.Slave, slaveDataSource);
+
+        routingDataSource.setTargetDataSources(dataSourceMap);
+        routingDataSource.setDefaultTargetDataSource(masterDataSource);
+
+        return routingDataSource;
+    }
+
+    @Bean(name = "dataSource")
+    public DataSource dataSource(@Qualifier("routingDataSource") DataSource routingDataSource) {
+        return new LazyConnectionDataSourceProxy(routingDataSource);
+    }
+}

--- a/src/test/java/com/example/soonsul/DBReplication/DataSourceTest.java
+++ b/src/test/java/com/example/soonsul/DBReplication/DataSourceTest.java
@@ -1,0 +1,61 @@
+package com.example.soonsul.DBReplication;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
+import javax.sql.DataSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@SpringBootTest(properties = "spring.config.location="
+        + "classpath:application.properties ,"
+        + "classpath:oauth.yml"
+)
+public class DataSourceTest {
+
+    @Autowired
+    Environment environment;
+
+
+    @Test
+    void Master_DataSource_테스트(@Qualifier("masterDataSource") final DataSource masterDataSource) {
+        //given
+        String url = environment.getProperty("spring.datasource.master.hikari.jdbc-url");
+        String username = environment.getProperty("spring.datasource.master.hikari.username");
+        String driverClassName = environment.getProperty("spring.datasource.master.hikari.driver-class-name");
+        Boolean readOnly = Boolean.valueOf(environment.getProperty("spring.datasource.master.hikari.read-only"));
+
+        //when
+        HikariDataSource hikariDataSource = (HikariDataSource) masterDataSource;
+
+        //then
+        assertThat(hikariDataSource.isReadOnly()).isEqualTo(readOnly);
+        assertThat(hikariDataSource.getJdbcUrl()).isEqualTo(url);
+        assertThat(hikariDataSource.getUsername()).isEqualTo(username);
+        assertThat(hikariDataSource.getDriverClassName()).isEqualTo(driverClassName);
+    }
+
+
+    @Test
+    void Slave_DataSource_테스트(@Qualifier("slaveDataSource") final DataSource slaveDataSource) {
+        //given
+        String url = environment.getProperty("spring.datasource.slave.hikari.jdbc-url");
+        String username = environment.getProperty("spring.datasource.slave.hikari.username");
+        String driverClassName = environment.getProperty("spring.datasource.slave.hikari.driver-class-name");
+        Boolean readOnly = Boolean.valueOf(environment.getProperty("spring.datasource.slave.hikari.read-only"));
+
+        //when
+        HikariDataSource hikariDataSource = (HikariDataSource) slaveDataSource;
+
+        //then
+        assertThat(hikariDataSource.isReadOnly()).isEqualTo(readOnly);
+        assertThat(hikariDataSource.getJdbcUrl()).isEqualTo(url);
+        assertThat(hikariDataSource.getUsername()).isEqualTo(username);
+        assertThat(hikariDataSource.getDriverClassName()).isEqualTo(driverClassName);
+    }
+
+}

--- a/src/test/java/com/example/soonsul/DBReplication/ReplicationTest.java
+++ b/src/test/java/com/example/soonsul/DBReplication/ReplicationTest.java
@@ -1,0 +1,56 @@
+package com.example.soonsul.DBReplication;
+
+import com.example.soonsul.DBReplication.common.DataSourceType;
+import com.example.soonsul.DBReplication.replication.ReplicationRoutingDataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@SpringBootTest(properties = "spring.config.location="
+        + "classpath:application.properties ,"
+        + "classpath:oauth.yml"
+)
+public class ReplicationTest {
+
+    private static final String Test_Method_Name = "determineCurrentLookupKey";
+
+
+    @Test
+    @Transactional
+    void 쓰기전용_트랜잭션() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        //given
+        ReplicationRoutingDataSource replicationRoutingDataSource = new ReplicationRoutingDataSource();
+
+        //when
+        Method determineCurrentLookupKey = ReplicationRoutingDataSource.class.getDeclaredMethod(Test_Method_Name);
+        determineCurrentLookupKey.setAccessible(true);
+
+        DataSourceType dataSourceType = (DataSourceType) determineCurrentLookupKey.invoke(replicationRoutingDataSource);
+
+        //then
+        assertEquals(dataSourceType, DataSourceType.Master);
+    }
+
+
+    @Test
+    @Transactional(readOnly = true)
+    void 읽기전용_트랜잭션() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        //given
+        ReplicationRoutingDataSource replicationRoutingDataSource = new ReplicationRoutingDataSource();
+
+        //when
+        Method determineCurrentLookupKey = ReplicationRoutingDataSource.class.getDeclaredMethod(Test_Method_Name);
+        determineCurrentLookupKey.setAccessible(true);
+
+        DataSourceType dataSourceType = (DataSourceType) determineCurrentLookupKey.invoke(replicationRoutingDataSource);
+
+        //then
+        assertEquals(dataSourceType, DataSourceType.Slave);
+    }
+
+}


### PR DESCRIPTION
- DB를 master와 slave로 분리하여, @transactional(readOnly=false) 일때 master를 사용하고 @transactional(readOnly=true) 일때 slave를 사용하도록 구현했습니다.
- 데이터소스 생성 및 @transactional(readOnly=true/false)에 따른 dataSourceType 확인 기능을 테스트했습니다.